### PR TITLE
Update paralog.sh: cleaner list of loci

### DIFF
--- a/cluster_scripts/paralogs.sh
+++ b/cluster_scripts/paralogs.sh
@@ -73,7 +73,8 @@ echo $i >> para_table.txt
 echo -e "\n" >> para_table.txt
 done < par_list.txt
 
-sed -i '/^$/d' para_table.txt
+sed -i 's/[.].*//' para_table.txt # removes all the characters situated after any "." character 
+sed -i '/^$/d' para_table.txt # removes empty lines
 
 cat para_table.txt | sort -f | uniq > loci_list.txt
 


### PR DESCRIPTION
Added a command to have a clean list of loci (loci_list.txt). Basically, it removes all the characters situated after any "." character, in order to remove the paths of the files returned in par_list.txt by the find function. This precludes from potentially miss paralogs (and thus step 2.3 of README "Verifying paralogs haven't been missed" is no longer useful).