### PR TITLE
Update post_hybpiper.sh for names of more than 8 characters in namelist.txt

### DIFF
--- a/cluster_scripts/post_hybpiper.sh
+++ b/cluster_scripts/post_hybpiper.sh
@@ -25,7 +25,7 @@ rename -v '.oneline' '' *
 rename -v '.fasta' '.FNA' *
 
 for filename in *.FNA; do
-	sed '/^>/s/-.*//' > header.${filename}
+	sed '/^>/s/-.*//' $filename > header.${filename}
 done
 
 mkdir header

--- a/cluster_scripts/post_hybpiper.sh
+++ b/cluster_scripts/post_hybpiper.sh
@@ -25,7 +25,7 @@ rename -v '.oneline' '' *
 rename -v '.fasta' '.FNA' *
 
 for filename in *.FNA; do
-	sed -r 's/^>(.{8}).*/>\1/' $filename | sed '/^>/s/-.*//' > header.${filename}
+	sed '/^>/s/-.*//' > header.${filename}
 done
 
 mkdir header


### PR DESCRIPTION
Removed the command that trimmed the fasta headers to 8 characters. I removed this because when analyzes include individuals from several runs, it can occur that they have the same I##_T## name, so I added the run suffix, such as: RUN79_I11_T22. Trimming to 8 characters is thus very problematic in the downstream analyses, and it seems that the command removing everything after the "-" character is enough to get rid of the exon name in the header.