### PR TITLE
added warning about over-parallelization

### DIFF
--- a/cluster_scripts/hybpiper.sh
+++ b/cluster_scripts/hybpiper.sh
@@ -132,6 +132,7 @@ do
 	echo "python $path_to_tmp/reads_first.py -b $path_to_tmp/Angiosperms353_targetSequences.fasta -r $path_to_tmp/${name}_R1.fastq $path_to_tmp/${name}_R2.fastq --prefix $path_to_tmp/$name --cpu 1 --bwa" >> hybpiper_parallel.txt
 done < namelist.txt
 
+# /!\ Care must be taken to not overparallelise python because too many instances of python running at the same time on the same machine causes threading issues /!\
 #run jobs in lots of 8
 parallel -j 8 < hybpiper_parallel.txt
 


### PR DESCRIPTION
I just added a warning about over-parallelization.
I tried to run 2 jobs of hybpiper on the same node, with 11 tasks and 2 cpu/task for each job (so 44 python threads in total on the machine), and it caused threading issues (same error as here: https://stackoverflow.com/questions/52026652/openblas-blas-thread-init-pthread-create-resource-temporarily-unavailable or here: https://stackoverflow.com/questions/51256738/multiple-instances-of-python-running-simultaneously-limited-to-35).
So we should be careful of not launching too much python instances on the same machine (this care should imply checking if other jobs from other users are running python too)